### PR TITLE
Documentation Update for iterations flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Subdora.subdora_parse("main.myst")
 
 <p><b>Encoding python script to image</b></p>
 <p>*only supports png and jpg files</p>
-<code>C:>subdora --obfuscate main.py --img img.jpg --iterations 5 --time 5m</code>
+<code>C:>subdora --obfuscate main.py --img img.jpg --itr 5 --time 5m</code>
 
 <br><p>This will generate main.png file to run the image file use</p>
 


### PR DESCRIPTION
### Issue

In the current version, the --iterations flag seems to have been updated to --itr flag. Yet the same is not reflected in the documentation

### Snapshot

<img width="647" alt="subdora_pr" src="https://github.com/Lakshit-Karsoliya/Subdora/assets/46641503/59a7c994-93fc-4c33-9a5b-a82a8afe9fb7">

### Fix

- Updated the relevant line in the ReadME
